### PR TITLE
Fixed error where half cycle wasn't calculated correctly

### DIFF
--- a/navani/echem.py
+++ b/navani/echem.py
@@ -361,6 +361,7 @@ def neware_reader(filename: Union[str, Path]) -> pd.DataFrame:
     df['cycle change'] = False
     not_rest_idx = df[df['state'] != 'R'].index
     df.loc[not_rest_idx, 'cycle change'] = df.loc[not_rest_idx, 'state'].ne(df.loc[not_rest_idx, 'state'].shift())
+    df['half cycle'] = (df['cycle change'] == True).cumsum()
     return df
 
 


### PR DESCRIPTION
Made sure the Neware reader calculates half cycles consistently with the other file formats. Bug before where it was simply equal to full cycles